### PR TITLE
Issue #9 Group name is not populated from template params to constants

### DIFF
--- a/src/templates/k8soperator/Content/Crd/CRDConstants.cs
+++ b/src/templates/k8soperator/Content/Crd/CRDConstants.cs
@@ -2,7 +2,7 @@
 {
     internal class CRDConstants
     {
-        public const string Group = "xabaril.io";
+        public const string Group = "{{crdlowergroupname}}";
         public const string Version = "v1";
         public const string Plural = "{{crdlowername}}s";
     }


### PR DESCRIPTION
CRDContants modified -> {{crdlowergroupname}} instead of Xabaril.io